### PR TITLE
Neogitプラグインを追加しGit操作UIを設定

### DIFF
--- a/lua/plugins/neogit.lua
+++ b/lua/plugins/neogit.lua
@@ -1,0 +1,21 @@
+return {
+	"NeogitOrg/neogit",
+	lazy = true,
+	dependencies = {
+		"nvim-lua/plenary.nvim", -- required
+
+		-- Only one of these is needed.
+		"sindrets/diffview.nvim", -- optional
+		"esmuellert/codediff.nvim", -- optional
+
+		-- Only one of these is needed.
+		"nvim-telescope/telescope.nvim", -- optional
+		"ibhagwan/fzf-lua", -- optional
+		"nvim-mini/mini.pick", -- optional
+		"folke/snacks.nvim", -- optional
+	},
+	cmd = "Neogit",
+	keys = {
+		{ "<leader>gg", "<cmd>Neogit<cr>", desc = "Show Neogit UI" },
+	},
+}


### PR DESCRIPTION
## 変更内容

Neovimのプラグインとして [Neogit](https://github.com/NeogitOrg/neogit) を追加した。

- `lua/plugins/neogit.lua` を新規作成
- lazy.nvim によるレイジーロード設定（`cmd = "Neogit"` で遅延読み込み）
- キーマップ `<leader>gg` で Neogit UI を起動できるように設定
- 依存プラグインとして `plenary.nvim`、`diffview.nvim`、`telescope.nvim` 等を指定

## 変更理由

Neovim 上で Git 操作を GUI ライクに行えるようにするため。ターミナルや外部ツールに切り替えることなく、エディタ内で完結した Git ワークフローを実現する。

## 備考

- `diffview.nvim` や `telescope.nvim` など、依存プラグインの一部はオプションであり、いずれか1つが存在すれば動作する
- 現時点では最小限のキーマップのみ設定しており、必要に応じて追加設定を検討する