### PR TITLE
feat: ターミナルとファイルツリーに行番号・相対行番号を表示する設定を追加

### DIFF
--- a/lua/core/options.lua
+++ b/lua/core/options.lua
@@ -19,3 +19,12 @@ opt.foldenable = true
 opt.termguicolors = true
 opt.winblend = 20 -- Windowの透明度 (0-100)
 opt.pumblend = 20 -- ポップアップメニューの透明度 (0-100)
+
+-- ターミナルバッファでも行番号を表示する
+-- （Neovimはterm://バッファを開くと自動でnumber/relativenumberを無効にするため）
+vim.api.nvim_create_autocmd("TermOpen", {
+  callback = function()
+    vim.opt_local.number = true
+    vim.opt_local.relativenumber = true
+  end,
+})

--- a/lua/plugins/nvim-tree.lua
+++ b/lua/plugins/nvim-tree.lua
@@ -8,6 +8,11 @@ return {
 		vim.g.loaded_netrw = 1
 		vim.g.loaded_netrwPlugin = 1
 
-		require("nvim-tree").setup()
+		require("nvim-tree").setup({
+			view = {
+				number = true, -- ファイルツリーでも行番号を表示する
+				relativenumber = true, -- 相対行番号を表示
+			},
+		})
 	end,
 }


### PR DESCRIPTION
## 変更内容

- ターミナルバッファ (`term://`) を開いた際に行番号・相対行番号を表示するよう `TermOpen` autocmd を追加
- nvim-tree のファイルツリーペインでも行番号・相対行番号を表示するよう設定を追加

## 変更理由

Neovim はデフォルトでターミナルバッファと nvim-tree において行番号を無効化する。行番号が表示されないと相対移動（`5j` など）の距離感が掴みにくく、操作効率が低下するため、一貫して行番号を表示するよう統一した。

## 備考

- `TermOpen` イベントは `vim.opt_local` を使用しているため、ターミナルバッファのみに適用され他のバッファには影響しない
- nvim-tree の `view.number` / `view.relativenumber` オプションはプラグイン側が提供する設定であり、グローバルの `number` 設定とは独立して動作する