### PR TITLE
feat: Go言語サポートを追加（gopls LSPとgoimportsフォーマッタの設定）

### DIFF
--- a/lua/plugins/conform.lua
+++ b/lua/plugins/conform.lua
@@ -7,6 +7,7 @@ return {
       formatters_by_ft = {
         lua = { "stylua" },
         swift = { "swiftformat" },
+        go = { "goimports" },
       },
       format_on_save = {
         timeout_ms = 500,

--- a/lua/plugins/lsp/lsp-config.lua
+++ b/lua/plugins/lsp/lsp-config.lua
@@ -7,7 +7,7 @@ return {
      {
        "WhoIsSethDaniel/mason-tool-installer.nvim",
        opts = {
-         ensure_installed = { "stylua", "codelldb" },
+         ensure_installed = { "stylua", "codelldb", "goimports" },
        },
      },
    },
@@ -51,7 +51,7 @@ return {
      })
 
      require("mason-lspconfig").setup({
-       ensure_installed = { "lua_ls", "ts_ls", "pyright", "html", "cssls", "emmet_ls", "prismals", "kotlin_language_server", "jdtls" },
+       ensure_installed = { "lua_ls", "ts_ls", "pyright", "html", "cssls", "emmet_ls", "prismals", "kotlin_language_server", "jdtls", "gopls" },
        automatic_enable = {
          exclude = { "stylua" },
        },


### PR DESCRIPTION
## 変更内容

- `gopls`（Go言語サーバー）をLSPの自動インストール対象に追加
- `goimports`をフォーマッタの自動インストール対象に追加
- Go（`.go`）ファイルの保存時に`goimports`でフォーマットされるよう設定

## 変更理由

Go言語での開発をサポートするため、LSPによるコード補完・定義ジャンプと、保存時の自動フォーマット環境を整備した。

## 備考

- `gopls`は`mason-lspconfig`が管理し、`automatic_enable`により自動でNeovimのLSPクライアントに接続される
- `goimports`はフォーマットとともにimportの自動整理も行う