### PR TITLE
Neovimの日本語ヘルプとnvimdoc-jaプラグインを追加

### DIFF
--- a/lua/core/options.lua
+++ b/lua/core/options.lua
@@ -1,5 +1,5 @@
 -- 言語設定
-vim.cmd.language('ja_JP.utf8')
+vim.cmd.language('ja_JP.UTF-8')
 
 -- ヘルプファイルの言語設定
 vim.opt.helplang = { 'ja', 'en' }

--- a/lua/core/options.lua
+++ b/lua/core/options.lua
@@ -1,3 +1,9 @@
+-- 言語設定
+vim.cmd.language('ja_JP.utf8')
+
+-- ヘルプファイルの言語設定
+vim.opt.helplang = { 'ja', 'en' }
+
 -- 基本設定
 local opt = vim.opt
 opt.number = true

--- a/lua/plugins/nvimdoc-ja.lua
+++ b/lua/plugins/nvimdoc-ja.lua
@@ -1,0 +1,7 @@
+return {
+	"vim-jp/nvimdoc-ja",
+
+	-- 任意で遅延読み込み
+	keys = { "<F1>", "<Help>" },
+	event = "CmdlineEnter",
+}


### PR DESCRIPTION
## 変更内容

- `vim-jp/nvimdoc-ja` プラグインを追加し、Neovimの日本語ドキュメントを参照できるようにした
- `lua/core/options.lua` にシステムロケールを `ja_JP.utf8` に設定する `vim.cmd.language()` を追加した
- `helplang` オプションに `ja` を優先言語として設定し、日本語ヘルプを先に表示するようにした

## 変更理由

Neovimのヘルプドキュメントを日本語で閲覧できるようにするため。英語ドキュメントへのフォールバックも維持しつつ、日本語を優先表示することで、ドキュメント参照の利便性を向上させる。

## 備考

- `nvimdoc-ja` プラグインは `<F1>` / `<Help>` キー押下時およびコマンドライン入力時に遅延読み込みされるため、起動パフォーマンスへの影響は最小限
- `helplang = { 'ja', 'en' }` の順序により、日本語訳が存在する場合は日本語を、存在しない場合は英語ヘルプを表示する