### PR TITLE
org-mode をセットアップ

### DIFF
--- a/lua/plugins/nvim-orgmode.lua
+++ b/lua/plugins/nvim-orgmode.lua
@@ -1,0 +1,14 @@
+return {
+	"nvim-orgmode/orgmode",
+	event = "VeryLazy",
+	config = function()
+		-- Setup orgmode
+		local path = "~/Library/Mobile Documents/com~apple~CloudDocs/org/note.org"
+		require("orgmode").setup({
+			org_agenda_files = path,
+			org_default_notes_file = path,
+		})
+		-- Experimental LSP support
+		vim.lsp.enable("org")
+	end,
+}


### PR DESCRIPTION
## 概要
Neovimでも org-mode を使用できるように追加修正をしました。

## 参考文献
https://nvim-orgmode.github.io/tutorial
