### PR TITLE
シェルスクリプトの開発セットアップ

### DIFF
--- a/lua/plugins/conform.lua
+++ b/lua/plugins/conform.lua
@@ -9,6 +9,7 @@ return {
         swift = { "swiftformat" },
         go = { "goimports" },
         sh = { "shfmt" },
+        bash = { "shfmt" },
       },
       format_on_save = {
         timeout_ms = 500,

--- a/lua/plugins/lsp/lsp-config.lua
+++ b/lua/plugins/lsp/lsp-config.lua
@@ -30,6 +30,16 @@ return {
        },
      })
 
+     -- bashls 個別設定
+     vim.lsp.config("bashls", {
+       filetypes = { "sh", "bash" },
+       settings = {
+         bashIde = {
+           shellcheckPath = vim.fn.exepath("shellcheck"),
+         },
+       },
+     })
+
      -- sourcekit-lsp for Swift (Masonでは管理不可、Xcode同梱)
      vim.lsp.config("sourcekit", {
        capabilities = vim.tbl_deep_extend("force", capabilities, {

--- a/lua/plugins/nvim-treesitter.lua
+++ b/lua/plugins/nvim-treesitter.lua
@@ -1,42 +1,40 @@
 return {
   -- Treesitter: シンタックスハイライト
-    "nvim-treesitter/nvim-treesitter",
-    build = ":TSUpdate",
-    event = { "BufReadPost", "BufNewFile" },
-    main = "nvim-treesitter",
-    opts = {
-      ensure_installed = {
-        "lua",
-        "vim",
-        "vimdoc",
-        "javascript",
-        "typescript",
-        "tsx",
-        "python",
-        "html",
-        "css",
-        "json",
-        "yaml",
-        "markdown",
-        "markdown_inline",
-        "bash",
-        "go",
-        "rust",
-        "c",
-        "cpp",
-        "prisma",
-        "kotlin",
-        "java",
-        "swift",
-      },
-      sync_install = false,
-      auto_install = true,
-      highlight = {
-        enable = true,
-        additional_vim_regex_highlighting = false,
-      },
-      indent = {
-        enable = true,
-      },
-    },
+  "nvim-treesitter/nvim-treesitter",
+  branch = "main",
+  build = ":TSUpdate",
+  event = { "BufReadPost", "BufNewFile" },
+  config = function()
+    require("nvim-treesitter").install({
+      "lua",
+      "vim",
+      "vimdoc",
+      "javascript",
+      "typescript",
+      "tsx",
+      "python",
+      "html",
+      "css",
+      "json",
+      "yaml",
+      "markdown",
+      "markdown_inline",
+      "bash",
+      "go",
+      "rust",
+      "c",
+      "cpp",
+      "prisma",
+      "kotlin",
+      "java",
+      "swift",
+    })
+
+    vim.api.nvim_create_autocmd("FileType", {
+      callback = function()
+        pcall(vim.treesitter.start)
+        vim.bo.indentexpr = "v:lua.require'nvim-treesitter'.indentexpr()"
+      end,
+    })
+  end,
 }


### PR DESCRIPTION
- bashls 個別設定を追加して、shellcheckと明示的に連携させる
- conform.nvim のフォーマッタ対象に bash filetype を追加() shfmt
